### PR TITLE
Feat/#10 week6

### DIFF
--- a/2nd-Seminar/2nd-Seminar.xcodeproj/project.pbxproj
+++ b/2nd-Seminar/2nd-Seminar.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		6CBD1D442CBA599C00DFDCCF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6CBD1D432CBA599C00DFDCCF /* Assets.xcassets */; };
 		6CBD1D472CBA599C00DFDCCF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6CBD1D452CBA599C00DFDCCF /* LaunchScreen.storyboard */; };
 		6CBD1D502CBA5A1300DFDCCF /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6CBD1D4F2CBA5A1300DFDCCF /* SnapKit */; };
+		6CC415012CF9A8C200139A87 /* Week6UIHostingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC415002CF9A88800139A87 /* Week6UIHostingCell.swift */; };
+		6CC415032CF9B65C00139A87 /* Week6ChartCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC415022CF9B64200139A87 /* Week6ChartCellView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -104,6 +106,8 @@
 		6CBD1D432CBA599C00DFDCCF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6CBD1D462CBA599C00DFDCCF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6CBD1D482CBA599C00DFDCCF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6CC415002CF9A88800139A87 /* Week6UIHostingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week6UIHostingCell.swift; sourceTree = "<group>"; };
+		6CC415022CF9B64200139A87 /* Week6ChartCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week6ChartCellView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +155,7 @@
 		6CA355852CF9058A0056E49C /* TableView */ = {
 			isa = PBXGroup;
 			children = (
+				6CC415022CF9B64200139A87 /* Week6ChartCellView.swift */,
 				6CA355842CF9058A0056E49C /* PopularChatsTableCell.swift */,
 			);
 			path = TableView;
@@ -274,6 +279,7 @@
 		6CA355C52CF905C40056E49C /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				6CC415002CF9A88800139A87 /* Week6UIHostingCell.swift */,
 				6CA355C32CF905C40056E49C /* FinanceViewController.swift */,
 				6CA355C42CF905C40056E49C /* PopularChartsViewController.swift */,
 			);
@@ -459,11 +465,13 @@
 				6CA355A82CF905A60056E49C /* UserManager.swift in Sources */,
 				6CA355B52CF905B60056E49C /* FreeRankingApps.swift in Sources */,
 				6CA355B62CF905B60056E49C /* PaidRankingApps.swift in Sources */,
+				6CC415012CF9A8C200139A87 /* Week6UIHostingCell.swift in Sources */,
 				6CA355B72CF905B60056E49C /* SecondSectionApps.swift in Sources */,
 				6CA355B82CF905B60056E49C /* PopularChartsApp.swift in Sources */,
 				6CA355B92CF905B60056E49C /* FirstSectionApps.swift in Sources */,
 				6CA355BA2CF905B60056E49C /* DownloadState.swift in Sources */,
 				6CA355A92CF905A60056E49C /* NetworkError.swift in Sources */,
+				6CC415032CF9B65C00139A87 /* Week6ChartCellView.swift in Sources */,
 				6CA355AA2CF905A60056E49C /* UserService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/2nd-Seminar/2nd-Seminar.xcodeproj/project.pbxproj
+++ b/2nd-Seminar/2nd-Seminar.xcodeproj/project.pbxproj
@@ -7,24 +7,98 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6C0CF5ED2CC43616000180E0 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0CF5EC2CC43616000180E0 /* DetailViewController.swift */; };
-		6C0CF5EF2CC531B5000180E0 /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0CF5EE2CC531B5000180E0 /* ReviewViewController.swift */; };
-		6CBD1D3B2CBA599700DFDCCF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBD1D3A2CBA599700DFDCCF /* AppDelegate.swift */; };
-		6CBD1D3D2CBA599700DFDCCF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBD1D3C2CBA599700DFDCCF /* SceneDelegate.swift */; };
+		6CA355752CF904910056E49C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355722CF904910056E49C /* AppDelegate.swift */; };
+		6CA355762CF904910056E49C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355732CF904910056E49C /* SceneDelegate.swift */; };
+		6CA355782CF904C90056E49C /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355772CF904C90056E49C /* UIView+.swift */; };
+		6CA3557D2CF904F30056E49C /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3557A2CF904F30056E49C /* ReviewViewController.swift */; };
+		6CA3557E2CF904F30056E49C /* TossController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3557B2CF904F30056E49C /* TossController.swift */; };
+		6CA3557F2CF904F30056E49C /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355792CF904F30056E49C /* DetailViewController.swift */; };
+		6CA355832CF905800056E49C /* UserupdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355812CF905800056E49C /* UserupdateViewController.swift */; };
+		6CA355862CF9058A0056E49C /* PopularChatsTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355842CF9058A0056E49C /* PopularChatsTableCell.swift */; };
+		6CA355892CF905940056E49C /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355872CF905940056E49C /* SignupViewController.swift */; };
+		6CA3558C2CF9059E0056E49C /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3558A2CF9059E0056E49C /* SearchViewController.swift */; };
+		6CA3559F2CF905A60056E49C /* UserupdateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355982CF905A60056E49C /* UserupdateRequest.swift */; };
+		6CA355A02CF905A60056E49C /* LoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3558D2CF905A60056E49C /* LoginRequest.swift */; };
+		6CA355A12CF905A60056E49C /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3559A2CF905A60056E49C /* Environment.swift */; };
+		6CA355A22CF905A60056E49C /* SignupResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355962CF905A60056E49C /* SignupResponse.swift */; };
+		6CA355A32CF905A60056E49C /* MypageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355912CF905A60056E49C /* MypageResponse.swift */; };
+		6CA355A42CF905A60056E49C /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3558F2CF905A60056E49C /* LoginService.swift */; };
+		6CA355A52CF905A60056E49C /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355932CF905A60056E49C /* SearchResponse.swift */; };
+		6CA355A62CF905A60056E49C /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3558E2CF905A60056E49C /* LoginResponse.swift */; };
+		6CA355A72CF905A60056E49C /* SignupRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355952CF905A60056E49C /* SignupRequest.swift */; };
+		6CA355A82CF905A60056E49C /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3559C2CF905A60056E49C /* UserManager.swift */; };
+		6CA355A92CF905A60056E49C /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3559B2CF905A60056E49C /* NetworkError.swift */; };
+		6CA355AA2CF905A60056E49C /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA3559D2CF905A60056E49C /* UserService.swift */; };
+		6CA355AD2CF905AE0056E49C /* MypageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355AB2CF905AE0056E49C /* MypageViewController.swift */; };
+		6CA355B52CF905B60056E49C /* FreeRankingApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355B02CF905B60056E49C /* FreeRankingApps.swift */; };
+		6CA355B62CF905B60056E49C /* PaidRankingApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355B12CF905B60056E49C /* PaidRankingApps.swift */; };
+		6CA355B72CF905B60056E49C /* SecondSectionApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355B32CF905B60056E49C /* SecondSectionApps.swift */; };
+		6CA355B82CF905B60056E49C /* PopularChartsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355B22CF905B60056E49C /* PopularChartsApp.swift */; };
+		6CA355B92CF905B60056E49C /* FirstSectionApps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355AF2CF905B60056E49C /* FirstSectionApps.swift */; };
+		6CA355BA2CF905B60056E49C /* DownloadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355AE2CF905B60056E49C /* DownloadState.swift */; };
+		6CA355BD2CF905BD0056E49C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355BB2CF905BD0056E49C /* LoginViewController.swift */; };
+		6CA355C72CF905C40056E49C /* PaidRankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355C02CF905C40056E49C /* PaidRankingView.swift */; };
+		6CA355C82CF905C40056E49C /* PopularChartsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355C42CF905C40056E49C /* PopularChartsViewController.swift */; };
+		6CA355C92CF905C40056E49C /* FreeRankingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355BF2CF905C40056E49C /* FreeRankingView.swift */; };
+		6CA355CA2CF905C40056E49C /* FirstSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355BE2CF905C40056E49C /* FirstSectionView.swift */; };
+		6CA355CB2CF905C40056E49C /* SecondSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355C12CF905C40056E49C /* SecondSectionView.swift */; };
+		6CA355CC2CF905C40056E49C /* FinanceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355C32CF905C40056E49C /* FinanceViewController.swift */; };
+		6CA355D22CF905CD0056E49C /* PaidRankingCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355CF2CF905CD0056E49C /* PaidRankingCollectionCell.swift */; };
+		6CA355D32CF905CD0056E49C /* FirstSectionCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355CD2CF905CD0056E49C /* FirstSectionCollectionCell.swift */; };
+		6CA355D42CF905CD0056E49C /* FreeRankingCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355CE2CF905CD0056E49C /* FreeRankingCollectionCell.swift */; };
+		6CA355D52CF905CD0056E49C /* SecondSectionCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA355D02CF905CD0056E49C /* SecondSectionCollectionCell.swift */; };
+		6CA355D82CF905EE0056E49C /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 6CA355D72CF905EE0056E49C /* Then */; };
+		6CA355DB2CF906090056E49C /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 6CA355DA2CF906090056E49C /* Alamofire */; };
+		6CA355DE2CF906190056E49C /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 6CA355DD2CF906190056E49C /* KeychainAccess */; };
 		6CBD1D3F2CBA599700DFDCCF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBD1D3E2CBA599700DFDCCF /* ViewController.swift */; };
 		6CBD1D422CBA599700DFDCCF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6CBD1D402CBA599700DFDCCF /* Main.storyboard */; };
 		6CBD1D442CBA599C00DFDCCF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6CBD1D432CBA599C00DFDCCF /* Assets.xcassets */; };
 		6CBD1D472CBA599C00DFDCCF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6CBD1D452CBA599C00DFDCCF /* LaunchScreen.storyboard */; };
 		6CBD1D502CBA5A1300DFDCCF /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6CBD1D4F2CBA5A1300DFDCCF /* SnapKit */; };
-		6CBD1D522CBA5A1300DFDCCF /* SnapKit-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 6CBD1D512CBA5A1300DFDCCF /* SnapKit-Dynamic */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		6C0CF5EC2CC43616000180E0 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
-		6C0CF5EE2CC531B5000180E0 /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
+		6CA355722CF904910056E49C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6CA355732CF904910056E49C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		6CA355772CF904C90056E49C /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		6CA355792CF904F30056E49C /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		6CA3557A2CF904F30056E49C /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
+		6CA3557B2CF904F30056E49C /* TossController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TossController.swift; sourceTree = "<group>"; };
+		6CA355812CF905800056E49C /* UserupdateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserupdateViewController.swift; sourceTree = "<group>"; };
+		6CA355842CF9058A0056E49C /* PopularChatsTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularChatsTableCell.swift; sourceTree = "<group>"; };
+		6CA355872CF905940056E49C /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
+		6CA3558A2CF9059E0056E49C /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		6CA3558D2CF905A60056E49C /* LoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequest.swift; sourceTree = "<group>"; };
+		6CA3558E2CF905A60056E49C /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
+		6CA3558F2CF905A60056E49C /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
+		6CA355912CF905A60056E49C /* MypageResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageResponse.swift; sourceTree = "<group>"; };
+		6CA355932CF905A60056E49C /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
+		6CA355952CF905A60056E49C /* SignupRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRequest.swift; sourceTree = "<group>"; };
+		6CA355962CF905A60056E49C /* SignupResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupResponse.swift; sourceTree = "<group>"; };
+		6CA355982CF905A60056E49C /* UserupdateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserupdateRequest.swift; sourceTree = "<group>"; };
+		6CA3559A2CF905A60056E49C /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		6CA3559B2CF905A60056E49C /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		6CA3559C2CF905A60056E49C /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		6CA3559D2CF905A60056E49C /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		6CA355AB2CF905AE0056E49C /* MypageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageViewController.swift; sourceTree = "<group>"; };
+		6CA355AE2CF905B60056E49C /* DownloadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadState.swift; sourceTree = "<group>"; };
+		6CA355AF2CF905B60056E49C /* FirstSectionApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionApps.swift; sourceTree = "<group>"; };
+		6CA355B02CF905B60056E49C /* FreeRankingApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRankingApps.swift; sourceTree = "<group>"; };
+		6CA355B12CF905B60056E49C /* PaidRankingApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidRankingApps.swift; sourceTree = "<group>"; };
+		6CA355B22CF905B60056E49C /* PopularChartsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularChartsApp.swift; sourceTree = "<group>"; };
+		6CA355B32CF905B60056E49C /* SecondSectionApps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionApps.swift; sourceTree = "<group>"; };
+		6CA355BB2CF905BD0056E49C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		6CA355BE2CF905C40056E49C /* FirstSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionView.swift; sourceTree = "<group>"; };
+		6CA355BF2CF905C40056E49C /* FreeRankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRankingView.swift; sourceTree = "<group>"; };
+		6CA355C02CF905C40056E49C /* PaidRankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidRankingView.swift; sourceTree = "<group>"; };
+		6CA355C12CF905C40056E49C /* SecondSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionView.swift; sourceTree = "<group>"; };
+		6CA355C32CF905C40056E49C /* FinanceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinanceViewController.swift; sourceTree = "<group>"; };
+		6CA355C42CF905C40056E49C /* PopularChartsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularChartsViewController.swift; sourceTree = "<group>"; };
+		6CA355CD2CF905CD0056E49C /* FirstSectionCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionCollectionCell.swift; sourceTree = "<group>"; };
+		6CA355CE2CF905CD0056E49C /* FreeRankingCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRankingCollectionCell.swift; sourceTree = "<group>"; };
+		6CA355CF2CF905CD0056E49C /* PaidRankingCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaidRankingCollectionCell.swift; sourceTree = "<group>"; };
+		6CA355D02CF905CD0056E49C /* SecondSectionCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionCollectionCell.swift; sourceTree = "<group>"; };
 		6CBD1D372CBA599700DFDCCF /* 2nd-Seminar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "2nd-Seminar.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6CBD1D3A2CBA599700DFDCCF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		6CBD1D3C2CBA599700DFDCCF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		6CBD1D3E2CBA599700DFDCCF /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		6CBD1D412CBA599700DFDCCF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		6CBD1D432CBA599C00DFDCCF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -38,13 +112,194 @@
 			buildActionMask = 2147483647;
 			files = (
 				6CBD1D502CBA5A1300DFDCCF /* SnapKit in Frameworks */,
-				6CBD1D522CBA5A1300DFDCCF /* SnapKit-Dynamic in Frameworks */,
+				6CA355DB2CF906090056E49C /* Alamofire in Frameworks */,
+				6CA355D82CF905EE0056E49C /* Then in Frameworks */,
+				6CA355DE2CF906190056E49C /* KeychainAccess in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6CA355742CF904910056E49C /* App */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355722CF904910056E49C /* AppDelegate.swift */,
+				6CA355732CF904910056E49C /* SceneDelegate.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		6CA3557C2CF904F30056E49C /* TOSS */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355792CF904F30056E49C /* DetailViewController.swift */,
+				6CA3557A2CF904F30056E49C /* ReviewViewController.swift */,
+				6CA3557B2CF904F30056E49C /* TossController.swift */,
+			);
+			path = TOSS;
+			sourceTree = "<group>";
+		};
+		6CA355822CF905800056E49C /* UserUpdate */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355812CF905800056E49C /* UserupdateViewController.swift */,
+			);
+			path = UserUpdate;
+			sourceTree = "<group>";
+		};
+		6CA355852CF9058A0056E49C /* TableView */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355842CF9058A0056E49C /* PopularChatsTableCell.swift */,
+			);
+			path = TableView;
+			sourceTree = "<group>";
+		};
+		6CA355882CF905940056E49C /* Signup */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355872CF905940056E49C /* SignupViewController.swift */,
+			);
+			path = Signup;
+			sourceTree = "<group>";
+		};
+		6CA3558B2CF9059E0056E49C /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				6CA3558A2CF9059E0056E49C /* SearchViewController.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		6CA355902CF905A60056E49C /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				6CA3558D2CF905A60056E49C /* LoginRequest.swift */,
+				6CA3558E2CF905A60056E49C /* LoginResponse.swift */,
+				6CA3558F2CF905A60056E49C /* LoginService.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		6CA355922CF905A60056E49C /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355912CF905A60056E49C /* MypageResponse.swift */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		6CA355942CF905A60056E49C /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355932CF905A60056E49C /* SearchResponse.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		6CA355972CF905A60056E49C /* Signup */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355952CF905A60056E49C /* SignupRequest.swift */,
+				6CA355962CF905A60056E49C /* SignupResponse.swift */,
+			);
+			path = Signup;
+			sourceTree = "<group>";
+		};
+		6CA355992CF905A60056E49C /* UserUpdate */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355982CF905A60056E49C /* UserupdateRequest.swift */,
+			);
+			path = UserUpdate;
+			sourceTree = "<group>";
+		};
+		6CA3559E2CF905A60056E49C /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355902CF905A60056E49C /* Login */,
+				6CA355922CF905A60056E49C /* MyPage */,
+				6CA355942CF905A60056E49C /* Search */,
+				6CA355972CF905A60056E49C /* Signup */,
+				6CA355992CF905A60056E49C /* UserUpdate */,
+				6CA3559A2CF905A60056E49C /* Environment.swift */,
+				6CA3559B2CF905A60056E49C /* NetworkError.swift */,
+				6CA3559C2CF905A60056E49C /* UserManager.swift */,
+				6CA3559D2CF905A60056E49C /* UserService.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		6CA355AC2CF905AE0056E49C /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355AB2CF905AE0056E49C /* MypageViewController.swift */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		6CA355B42CF905B60056E49C /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355AE2CF905B60056E49C /* DownloadState.swift */,
+				6CA355AF2CF905B60056E49C /* FirstSectionApps.swift */,
+				6CA355B02CF905B60056E49C /* FreeRankingApps.swift */,
+				6CA355B12CF905B60056E49C /* PaidRankingApps.swift */,
+				6CA355B22CF905B60056E49C /* PopularChartsApp.swift */,
+				6CA355B32CF905B60056E49C /* SecondSectionApps.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		6CA355BC2CF905BD0056E49C /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355BB2CF905BD0056E49C /* LoginViewController.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		6CA355C22CF905C40056E49C /* View */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355BE2CF905C40056E49C /* FirstSectionView.swift */,
+				6CA355BF2CF905C40056E49C /* FreeRankingView.swift */,
+				6CA355C02CF905C40056E49C /* PaidRankingView.swift */,
+				6CA355C12CF905C40056E49C /* SecondSectionView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		6CA355C52CF905C40056E49C /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355C32CF905C40056E49C /* FinanceViewController.swift */,
+				6CA355C42CF905C40056E49C /* PopularChartsViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		6CA355C62CF905C40056E49C /* Finance */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355C22CF905C40056E49C /* View */,
+				6CA355C52CF905C40056E49C /* ViewController */,
+			);
+			path = Finance;
+			sourceTree = "<group>";
+		};
+		6CA355D12CF905CD0056E49C /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				6CA355CD2CF905CD0056E49C /* FirstSectionCollectionCell.swift */,
+				6CA355CE2CF905CD0056E49C /* FreeRankingCollectionCell.swift */,
+				6CA355CF2CF905CD0056E49C /* PaidRankingCollectionCell.swift */,
+				6CA355D02CF905CD0056E49C /* SecondSectionCollectionCell.swift */,
+			);
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
 		6CBD1D2E2CBA599700DFDCCF = {
 			isa = PBXGroup;
 			children = (
@@ -64,15 +319,24 @@
 		6CBD1D392CBA599700DFDCCF /* 2nd-Seminar */ = {
 			isa = PBXGroup;
 			children = (
-				6CBD1D3A2CBA599700DFDCCF /* AppDelegate.swift */,
-				6CBD1D3C2CBA599700DFDCCF /* SceneDelegate.swift */,
+				6CA355B42CF905B60056E49C /* Model */,
+				6CA355D12CF905CD0056E49C /* CollectionView */,
+				6CA355C62CF905C40056E49C /* Finance */,
+				6CA355BC2CF905BD0056E49C /* Login */,
+				6CA355AC2CF905AE0056E49C /* MyPage */,
+				6CA3559E2CF905A60056E49C /* Network */,
+				6CA3558B2CF9059E0056E49C /* Search */,
+				6CA355882CF905940056E49C /* Signup */,
+				6CA355852CF9058A0056E49C /* TableView */,
+				6CA355822CF905800056E49C /* UserUpdate */,
+				6CA3557C2CF904F30056E49C /* TOSS */,
+				6CA355772CF904C90056E49C /* UIView+.swift */,
+				6CA355742CF904910056E49C /* App */,
 				6CBD1D3E2CBA599700DFDCCF /* ViewController.swift */,
 				6CBD1D402CBA599700DFDCCF /* Main.storyboard */,
 				6CBD1D432CBA599C00DFDCCF /* Assets.xcassets */,
 				6CBD1D452CBA599C00DFDCCF /* LaunchScreen.storyboard */,
 				6CBD1D482CBA599C00DFDCCF /* Info.plist */,
-				6C0CF5EC2CC43616000180E0 /* DetailViewController.swift */,
-				6C0CF5EE2CC531B5000180E0 /* ReviewViewController.swift */,
 			);
 			path = "2nd-Seminar";
 			sourceTree = "<group>";
@@ -95,7 +359,9 @@
 			name = "2nd-Seminar";
 			packageProductDependencies = (
 				6CBD1D4F2CBA5A1300DFDCCF /* SnapKit */,
-				6CBD1D512CBA5A1300DFDCCF /* SnapKit-Dynamic */,
+				6CA355D72CF905EE0056E49C /* Then */,
+				6CA355DA2CF906090056E49C /* Alamofire */,
+				6CA355DD2CF906190056E49C /* KeychainAccess */,
 			);
 			productName = "2nd-Seminar";
 			productReference = 6CBD1D372CBA599700DFDCCF /* 2nd-Seminar.app */;
@@ -127,6 +393,9 @@
 			mainGroup = 6CBD1D2E2CBA599700DFDCCF;
 			packageReferences = (
 				6CBD1D4E2CBA5A1300DFDCCF /* XCRemoteSwiftPackageReference "SnapKit" */,
+				6CA355D62CF905EE0056E49C /* XCRemoteSwiftPackageReference "Then" */,
+				6CA355D92CF906090056E49C /* XCRemoteSwiftPackageReference "Alamofire" */,
+				6CA355DC2CF906190056E49C /* XCRemoteSwiftPackageReference "KeychainAccess" */,
 			);
 			productRefGroup = 6CBD1D382CBA599700DFDCCF /* Products */;
 			projectDirPath = "";
@@ -155,11 +424,47 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6CA355782CF904C90056E49C /* UIView+.swift in Sources */,
+				6CA3558C2CF9059E0056E49C /* SearchViewController.swift in Sources */,
+				6CA3557D2CF904F30056E49C /* ReviewViewController.swift in Sources */,
+				6CA355C72CF905C40056E49C /* PaidRankingView.swift in Sources */,
+				6CA355C82CF905C40056E49C /* PopularChartsViewController.swift in Sources */,
+				6CA355C92CF905C40056E49C /* FreeRankingView.swift in Sources */,
+				6CA355CA2CF905C40056E49C /* FirstSectionView.swift in Sources */,
+				6CA355CB2CF905C40056E49C /* SecondSectionView.swift in Sources */,
+				6CA355CC2CF905C40056E49C /* FinanceViewController.swift in Sources */,
+				6CA355892CF905940056E49C /* SignupViewController.swift in Sources */,
+				6CA355832CF905800056E49C /* UserupdateViewController.swift in Sources */,
+				6CA3557E2CF904F30056E49C /* TossController.swift in Sources */,
+				6CA3557F2CF904F30056E49C /* DetailViewController.swift in Sources */,
+				6CA355862CF9058A0056E49C /* PopularChatsTableCell.swift in Sources */,
 				6CBD1D3F2CBA599700DFDCCF /* ViewController.swift in Sources */,
-				6CBD1D3B2CBA599700DFDCCF /* AppDelegate.swift in Sources */,
-				6C0CF5EF2CC531B5000180E0 /* ReviewViewController.swift in Sources */,
-				6CBD1D3D2CBA599700DFDCCF /* SceneDelegate.swift in Sources */,
-				6C0CF5ED2CC43616000180E0 /* DetailViewController.swift in Sources */,
+				6CA355752CF904910056E49C /* AppDelegate.swift in Sources */,
+				6CA355762CF904910056E49C /* SceneDelegate.swift in Sources */,
+				6CA3559F2CF905A60056E49C /* UserupdateRequest.swift in Sources */,
+				6CA355A02CF905A60056E49C /* LoginRequest.swift in Sources */,
+				6CA355D22CF905CD0056E49C /* PaidRankingCollectionCell.swift in Sources */,
+				6CA355D32CF905CD0056E49C /* FirstSectionCollectionCell.swift in Sources */,
+				6CA355D42CF905CD0056E49C /* FreeRankingCollectionCell.swift in Sources */,
+				6CA355D52CF905CD0056E49C /* SecondSectionCollectionCell.swift in Sources */,
+				6CA355BD2CF905BD0056E49C /* LoginViewController.swift in Sources */,
+				6CA355A12CF905A60056E49C /* Environment.swift in Sources */,
+				6CA355A22CF905A60056E49C /* SignupResponse.swift in Sources */,
+				6CA355AD2CF905AE0056E49C /* MypageViewController.swift in Sources */,
+				6CA355A32CF905A60056E49C /* MypageResponse.swift in Sources */,
+				6CA355A42CF905A60056E49C /* LoginService.swift in Sources */,
+				6CA355A52CF905A60056E49C /* SearchResponse.swift in Sources */,
+				6CA355A62CF905A60056E49C /* LoginResponse.swift in Sources */,
+				6CA355A72CF905A60056E49C /* SignupRequest.swift in Sources */,
+				6CA355A82CF905A60056E49C /* UserManager.swift in Sources */,
+				6CA355B52CF905B60056E49C /* FreeRankingApps.swift in Sources */,
+				6CA355B62CF905B60056E49C /* PaidRankingApps.swift in Sources */,
+				6CA355B72CF905B60056E49C /* SecondSectionApps.swift in Sources */,
+				6CA355B82CF905B60056E49C /* PopularChartsApp.swift in Sources */,
+				6CA355B92CF905B60056E49C /* FirstSectionApps.swift in Sources */,
+				6CA355BA2CF905B60056E49C /* DownloadState.swift in Sources */,
+				6CA355A92CF905A60056E49C /* NetworkError.swift in Sources */,
+				6CA355AA2CF905A60056E49C /* UserService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -384,6 +689,30 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		6CA355D62CF905EE0056E49C /* XCRemoteSwiftPackageReference "Then" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/devxoul/Then";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
+			};
+		};
+		6CA355D92CF906090056E49C /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.2;
+			};
+		};
+		6CA355DC2CF906190056E49C /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		6CBD1D4E2CBA5A1300DFDCCF /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -395,15 +724,25 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		6CA355D72CF905EE0056E49C /* Then */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CA355D62CF905EE0056E49C /* XCRemoteSwiftPackageReference "Then" */;
+			productName = Then;
+		};
+		6CA355DA2CF906090056E49C /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CA355D92CF906090056E49C /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		6CA355DD2CF906190056E49C /* KeychainAccess */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CA355DC2CF906190056E49C /* XCRemoteSwiftPackageReference "KeychainAccess" */;
+			productName = KeychainAccess;
+		};
 		6CBD1D4F2CBA5A1300DFDCCF /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6CBD1D4E2CBA5A1300DFDCCF /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		6CBD1D512CBA5A1300DFDCCF /* SnapKit-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6CBD1D4E2CBA5A1300DFDCCF /* XCRemoteSwiftPackageReference "SnapKit" */;
-			productName = "SnapKit-Dynamic";
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/2nd-Seminar/2nd-Seminar.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/2nd-Seminar/2nd-Seminar.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,24 @@
 {
+  "originHash" : "a3dfce941f55040604fdd2a0158df52359ab6d4673e90ec47e1e4d164bda3825",
   "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
+      "state" : {
+        "branch" : "master",
+        "revision" : "e0c7eebc5a4465a3c4680764f26b7a61f567cdaf"
+      }
+    },
     {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
@@ -8,7 +27,16 @@
         "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
         "version" : "5.7.1"
       }
+    },
+    {
+      "identity" : "then",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devxoul/Then",
+      "state" : {
+        "revision" : "d41ef523faef0f911369f79c0b96815d9dbb6d7a",
+        "version" : "3.0.0"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/2nd-Seminar/2nd-Seminar/Finance/ViewController/FinanceViewController.swift
+++ b/2nd-Seminar/2nd-Seminar/Finance/ViewController/FinanceViewController.swift
@@ -139,5 +139,5 @@ extension FinanceViewController: UICollectionViewDataSource, UICollectionViewDel
 }
 
 #Preview {
-    ViewController()
+    FinanceViewController()
 }

--- a/2nd-Seminar/2nd-Seminar/Finance/ViewController/PopularChartsViewController.swift
+++ b/2nd-Seminar/2nd-Seminar/Finance/ViewController/PopularChartsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 
 import SnapKit
 
@@ -8,12 +9,17 @@ protocol TableCellDelegate: AnyObject {
 
 class PopularChartsViewController: UIViewController {
     
+    // MARK: - Properties
+    
     private let tableView = UITableView(frame: .zero, style: .plain).then {
         $0.backgroundColor = .black
         
     }
 
     private let appList = PopularChartsApp.popularApps
+    
+    
+    // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,6 +40,7 @@ class PopularChartsViewController: UIViewController {
         
     }
     
+    // MARK: - Private Func
     
     private func setUI() {
         self.view.addSubview(tableView)
@@ -46,7 +53,7 @@ class PopularChartsViewController: UIViewController {
     }
     
     private func register() {
-        tableView.register(PopularChartsTableCell.self, forCellReuseIdentifier: PopularChartsTableCell.identifier)
+        tableView.register(Week6UIHostingCell<Week6ChartCellView>.self, forCellReuseIdentifier: "Week6UIHostingCell")
     }
     
     private func setDelegate() {
@@ -54,6 +61,8 @@ class PopularChartsViewController: UIViewController {
         tableView.dataSource = self
     }
 }
+
+// MARK: - Extension
 
 extension PopularChartsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -67,14 +76,28 @@ extension PopularChartsViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-      guard let cell = tableView.dequeueReusableCell(
-        withIdentifier: PopularChartsTableCell.identifier,
-        for: indexPath
-      ) as? PopularChartsTableCell else { return UITableViewCell() }
-        cell.delegate = self
-        cell.configurate(app: appList[indexPath.row], index: indexPath.row)
-      return cell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "Week6UIHostingCell", for: indexPath) as? Week6UIHostingCell<Week6ChartCellView> else {
+            return UITableViewCell()
+        }
+        
+        let app = appList[indexPath.row]
+        let swiftUIView = Week6ChartCellView(app: app, index: indexPath.row) {
+            print("\(app.title)") //버튼 누르면 app 이름 출력
+        }
+        
+        cell.configure(with: swiftUIView, parent: self)
+        return cell
     }
+    
+//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//      guard let cell = tableView.dequeueReusableCell(
+//        withIdentifier: PopularChartsTableCell.identifier,
+//        for: indexPath
+//      ) as? PopularChartsTableCell else { return UITableViewCell() }
+//        cell.delegate = self
+//        cell.configurate(app: appList[indexPath.row], index: indexPath.row)
+//      return cell
+//    }
   }
 
 extension PopularChartsViewController: TableCellDelegate {
@@ -85,3 +108,8 @@ extension PopularChartsViewController: TableCellDelegate {
         }
     }
 }
+
+#Preview {
+    PopularChartsViewController()
+}
+

--- a/2nd-Seminar/2nd-Seminar/Finance/ViewController/Week6UIHostingCell.swift
+++ b/2nd-Seminar/2nd-Seminar/Finance/ViewController/Week6UIHostingCell.swift
@@ -1,0 +1,53 @@
+//
+//  Week6UIHostingCell.swift
+//  2nd-Seminar
+//
+//  Created by MaengKim on 11/29/24.
+//
+import UIKit
+import SwiftUI
+
+import SnapKit
+
+public class Week6UIHostingCell<Content: View>: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    private var hostingController = UIHostingController<Content?>(rootView: nil)
+    
+    // MARK: - Init
+    
+    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        contentView.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: contentView.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Func
+    
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        hostingController.willMove(toParent: nil)
+        hostingController.rootView = nil
+        hostingController.removeFromParent()
+    }
+    
+    public func configure(with view: Content, parent: UIViewController) {
+        parent.addChild(hostingController)
+        hostingController.rootView = view
+        hostingController.view.invalidateIntrinsicContentSize()
+        hostingController.didMove(toParent: parent)
+    }
+}

--- a/2nd-Seminar/2nd-Seminar/Model/PopularChartsApp.swift
+++ b/2nd-Seminar/2nd-Seminar/Model/PopularChartsApp.swift
@@ -1,4 +1,3 @@
-import Foundation
 import UIKit
 
 struct PopularChartsApp {

--- a/2nd-Seminar/2nd-Seminar/TableView/Week6ChartCellView.swift
+++ b/2nd-Seminar/2nd-Seminar/TableView/Week6ChartCellView.swift
@@ -1,0 +1,52 @@
+//
+//  Week6ChartCell.swift
+//  2nd-Seminar
+//
+//  Created by MaengKim on 11/29/24.
+//
+import SwiftUI
+
+struct Week6ChartCellView: View {
+    let app: PopularChartsApp
+    let index: Int
+    let buttonTapped: () -> Void
+    
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(uiImage: app.iconImage)
+                .resizable()
+                .frame(width: 65, height: 65)
+                .cornerRadius(15)
+            
+            VStack(alignment: .leading, spacing: 5) {
+                HStack {
+                    Text("\(app.ranking)")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundColor(.white)
+                    
+                    Text(app.title)
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(.white)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                }
+                Text(app.subTitle)
+                    .font(.system(size: 15))
+                    .foregroundColor(.gray)
+                    .lineLimit(1)
+            }
+            Spacer()
+            
+            Button(action: buttonTapped) {
+                Text(app.downloadState.rawValue)
+                    .font(.system(size: 15, weight: .semibold))
+                    .frame(width: 60, height: 25)
+                    .background(Color.gray)
+                    .foregroundColor(.blue)
+                    .cornerRadius(12)
+            }
+        }
+        .padding()
+        .background(Color.black)
+    }
+}


### PR DESCRIPTION
## 📌 Issue
#10 

## 💨 Description
<!-- 내용 설명 -->
- 6주차 세미나 과제입니다.
- 이전 과제의 앱스토어 금융 카테고리 인기차트 부분을 UIKit의 TableView에서 SwiftUI 로 변경하였습니다.
- 기존 UIKit 위에 SwiftUI를 구현하고자 UIHostingController를 사용하였습니다.
- TableView의 Cell을 SwiftUI를 이용하여 구현하였습니다.

## 📸 Screenshot
![simulator_screenshot_9E74B17F-704A-4F8B-B3F2-5C38A67A5C08](https://github.com/user-attachments/assets/3596f8f1-ed39-4fdf-bfdb-1844eb25b0fc)

## 💭 To Reviewers
UIKit랑 매우 다르네요 .. 😵 기존 UIKit에 SwiftUI로 넣어보고자 했습니다 .. !
## 📚 Reference
- https://mini-min-dev.tistory.com/287
- https://medium.com/@hongseongho/uitableviewcell%EC%97%90%EC%84%9C-swiftui-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-43321a9e9e90
- https://github.com/cozzin/UIHosting/blob/main/UIHosting/UIHostingCell.swift
